### PR TITLE
Remove multipart/form-data for /simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "amq-protocol"
 version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,27 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
-name = "bzip2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
 dependencies = [
  "percent-encoding",
- "time 0.2.27",
+ "time",
  "version_check",
 ]
 
@@ -412,15 +385,6 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
-
-[[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -563,13 +527,10 @@ dependencies = [
  "rocket",
  "rocket_dyn_templates",
  "rocket_okapi",
- "rocket_okapi_codegen",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
- "yup-hyper-mock",
- "zip",
 ]
 
 [[package]]
@@ -644,18 +605,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1194,16 +1143,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
 
 [[package]]
 name = "mio"
@@ -1797,7 +1736,7 @@ dependencies = [
  "serde_json",
  "state",
  "tempfile",
- "time 0.2.27",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1860,7 +1799,7 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.2.27",
+ "time",
  "tokio",
  "uncased",
 ]
@@ -2234,36 +2173,6 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
  "winapi 0.3.9",
 ]
 
@@ -2672,30 +2581,3 @@ name = "yansi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
-
-[[package]]
-name = "yup-hyper-mock"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01da7b30633bf0a0a95443eb9dd524bda44c96072e19a7d0d775c96336d91d96"
-dependencies = [
- "futures",
- "hyper",
- "log",
- "mio 0.6.23",
- "tokio",
-]
-
-[[package]]
-name = "zip"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
-dependencies = [
- "byteorder",
- "bzip2",
- "crc32fast",
- "flate2",
- "thiserror",
- "time 0.1.43",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,15 @@ redis = "0.20.1"
 log = "0.4.14"
 doc-comment = "0.3.3"
 bytes = "1.0.1"
-zip = "0.5.12"
 assert-json-diff = "2.0.1"
 lapin = "1.7.1"
 async-global-executor = "2.0.2"
 handlebars = "4.0.1"
 paste = "1.0.5"
-schemars = "^0.8"
+schemars = "^0.8.1"
 either = "1.6.1"
 okapi = "0.7.0-rc.1"
-rocket_okapi = "0.8.0-rc.1"
-rocket_okapi_codegen = "0.8.0-rc.1"
+rocket_okapi = { version="0.8.0-rc.1", features = ["swagger"] }
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -9,8 +9,10 @@ use log::info;
 use lapin::{
     Result,
 };
-use crate::routes::AMQPSimulation;
-use rocket::serde::json::json;
+use crate::routes::{Simulation, SimulationType};
+use rocket::serde::json::{json, Json};
+use serde::{ Serialize, Deserialize };
+use schemars::JsonSchema;
 #[cfg(test)]
 pub async fn publish(bytes: Vec<u8>) -> Result<()> {
     println!("AMQPSimulation: {:?}", bytes);
@@ -51,6 +53,28 @@ pub async fn publish(bytes: Vec<u8>) -> Result<()> {
         .await?;
     assert_eq!(confirm, Confirmation::NotRequested);
     Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[doc = "Struct for encapsulation Simulation details"]
+pub struct AMQPSimulation {
+    error: String,
+    load_profile_url:  String,
+    model_url:         String,
+    simulation_id:     u64,
+    simulation_type:   SimulationType,
+}
+
+impl AMQPSimulation {
+    pub fn from_simulation(sim: &Json<Simulation>, model_url: String, load_profile_url: String) -> AMQPSimulation {
+        AMQPSimulation {
+            error:            "".into(),
+            simulation_id:    sim.simulation_id,
+            load_profile_url: load_profile_url,
+            model_url:        model_url,
+            simulation_type:  sim.simulation_type,
+        }
+    }
 }
 
 pub async fn request_simulation(_simulation: &AMQPSimulation) -> Result<()> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 
 extern crate redis;
 use redis::{Commands, RedisResult};
-use crate::Simulation;
+use crate::routes::Simulation;
 
 fn get_connection() -> redis::RedisResult<redis::Connection> {
     let client = redis::Client::open("redis://redis-master/")?;
@@ -15,7 +15,7 @@ pub fn get_new_simulation_id() -> RedisResult<u64> {
 }
 
 #[doc = "Function for writing a Simulation into a Redis DB"]
-pub fn write_simulation(key: &String, value: &super::Simulation) -> Result<(), redis::RedisError> {
+pub fn write_simulation(key: &String, value: &Simulation) -> Result<(), redis::RedisError> {
     let mut conn = get_connection()?;
     match serde_json::to_string(value) {
         Ok(value_str) => conn.set(key, value_str),

--- a/src/file_service.rs
+++ b/src/file_service.rs
@@ -27,8 +27,6 @@ pub async fn get_data_from_url(url: &str) -> Result<Box<Bytes>, hyper::Error> {
 
     // Await the response...
     let mut resp = client.get(uri).await?;
-    println!("Response: {}", resp.status());
-
     let body = resp.body_mut();
     let mut buf = BytesMut::with_capacity(body.size_hint().lower() as usize);
     while let Some(chunk) = body.data().await {
@@ -48,11 +46,16 @@ pub async fn convert_id_to_url(model_id: &str) -> Result<String, hyper::Error>{
         Ok(boxed_data) => {
             let body = std::str::from_utf8(&boxed_data).unwrap();
             let body_json: serde_json::Value = serde_json::from_str(body).unwrap();
-            let url_str = body_json["data"]["url"].as_str().unwrap();
-            url_str.into()
+            if body_json.get("data".to_string()) != None {
+                let url_str = body_json["data"]["url"].as_str().unwrap();
+                url_str.into()
+            }
+            else {
+                let error_str = body_json["error"]["message"].as_str().unwrap();
+                error_str.into()
+            }
         },
         Err(error) => {
-            println!("ERROR: {}", error);
             error.to_string()
         }
     };


### PR DESCRIPTION
Currently the load profile data for a simulation request is sent by using multipart/form-data for the /simulation endpoint post.
This is not consistent with using sogno/file-service for the model data and makes the swagger ui more complicated to implement.
We should move to using json for the /simuation endpoint with a file-service id for the load profile data.
This will mean that the form parameters in the swagger UI will be listed correctly, helping the user / developer to fill out the form.