### PR TITLE
Add parameters domain, solver, timestep, finaltime

### DIFF
--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -3,9 +3,9 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/..
 pushd $SCRIPT_DIR && echo "Changed to $SCRIPT_DIR"
 
-docker build -f Dockerfile -t dpsim-api . && \
-docker tag dpsim-api:latest localhost:5000/dpsim-api && \
-docker push localhost:5000/dpsim-api
+docker build -f Dockerfile -t dpsim:api . && \
+docker tag dpsim:api localhost:5000/dpsim:api && \
+docker push localhost:5000/dpsim:api
 
 if [ "$?" != "0" ];
 then

--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -9,7 +9,7 @@ use log::info;
 use lapin::{
     Result,
 };
-use crate::routes::{Simulation, SimulationType};
+use crate::routes::{Simulation, SimulationType, DomainType, SolverType};
 use rocket::serde::json::{json, Json};
 use serde::{ Serialize, Deserialize };
 use schemars::JsonSchema;
@@ -63,7 +63,11 @@ pub struct AMQPSimulation {
     model_url:         String,
     simulation_id:     u64,
     simulation_type:   SimulationType,
-    results_file:      String
+    results_file:      String,
+    domain:            DomainType,
+    solver:            SolverType,
+    timestep:          u64,
+    finaltime:         u64
 }
 
 impl AMQPSimulation {
@@ -75,6 +79,10 @@ impl AMQPSimulation {
             simulation_id:    sim.simulation_id,
             simulation_type:  sim.simulation_type,
             results_file:     sim.results_id.clone(),
+            domain:          DomainType::SP,
+            solver:          SolverType::NRP,
+            timestep:        1,
+            finaltime:       360
         }
     }
 }
@@ -90,7 +98,11 @@ pub async fn request_simulation(_simulation: &AMQPSimulation) -> Result<()> {
         "url" : [ _simulation.model_url ]
       },
       "parameters": {
-        "results_file": _simulation.results_file,
+        "domain":          _simulation.domain,
+        "solver":          _simulation.solver,
+        "timestep":        _simulation.timestep,
+        "finaltime":       _simulation.finaltime,
+        "results_file":    _simulation.results_file,
         "executable": "SLEW_Shmem_CIGRE_MV_PowerFlow",
         "name": "SLEW_Shmem_CIGRE_MV_PowerFlow",
         "timestep": 0.1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ async fn main() -> Result <(), rocket::Error> {
 mod db {
     use redis::RedisResult;
     use crate::routes::{Simulation, SimulationType};
+    use crate::routes::{DomainType, SolverType};
     pub fn get_new_simulation_id() -> RedisResult<u64> {
         Ok(1)
     }
@@ -71,7 +72,11 @@ mod db {
                results_id:      "1".to_string(),
                results_data:    "1".to_string(),
                simulation_id:   1,
-               simulation_type: SimulationType::Powerflow
+               simulation_type: SimulationType::Powerflow,
+               domain:          DomainType::SP,
+               solver:          SolverType::NRP,
+               timestep:        1,
+               finaltime:       360
         })
     }
     pub fn write_u64(_key: &String, _value: u64) -> redis::RedisResult<()> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use rocket::local::blocking::Client;
 use rocket::Build;
 use serde::{Deserialize, Serialize};
-use crate::routes::{Simulation, SimulationType, get_routes, incomplete_form};
+use crate::routes::{Simulation, SimulationType, DomainType, SolverType, get_routes, incomplete_form};
 use rocket::http::ContentType;
 use serde_json::json;
 use assert_json_diff::assert_json_eq;
@@ -34,6 +34,10 @@ fn test_get_simulation() {
         results_data:    "".to_string(),
         simulation_id:   1,
         simulation_type: SimulationType::Powerflow,
+        domain:          DomainType::SP,
+        solver:          SolverType::NRP,
+        timestep:        1,
+        finaltime:       360
     };
     assert_json_eq!(received_json, expected_json)
 }
@@ -53,6 +57,10 @@ fn test_get_simulation_by_id() {
         load_profile_id: "".to_string(),
         model_id:        "1".to_string(),
         results_id:      "1".to_string(),
+        domain:          DomainType::SP,
+        solver:          SolverType::NRP,
+        timestep:        1,
+        finaltime:       360,
         results_data:    r#"{
   "data": {
     "fileID": "d297cb7c-b578-4da8-9d79-76432e8986e9",
@@ -96,7 +104,15 @@ fn test_post_simulation() {
         .parse::<ContentType>()
         .unwrap();
    
-    let form = SimulationForm { model_id: "1".to_string(), load_profile_id: "1".to_string(), simulation_type: SimulationType::Powerflow.into() };
+    let form = SimulationForm {
+        model_id: "1".to_string(),
+        load_profile_id: "1".to_string(),
+        simulation_type: SimulationType::Powerflow.into(),
+        domain:          DomainType::SP,
+        solver:          SolverType::NRP,
+        timestep:        1,
+        finaltime:       360,
+    };
     let body = serde_json::to_string(&form).unwrap();
     let response = client.post("/simulation")
         .header(ct)
@@ -114,6 +130,10 @@ fn test_post_simulation() {
         results_data:      "".to_string(),
         simulation_id:     1,
         simulation_type:   SimulationType::Powerflow,
+        domain:            DomainType::SP,
+        solver:            SolverType::NRP,
+        timestep:          1,
+        finaltime:         360,
     });
     let received_json: Simulation = serde_json::from_str( reply.as_str() ).unwrap();
     assert_json_eq!(expected_simulation, received_json)


### PR DESCRIPTION
This change adds two new types
* DomainType
* SolverType

Four new parameters are added to the Simulation type and form:
* domain:   DomainType
* solver:     SolverType
* timestep: u64
* finaltime: u64

These new parameters are added to the AMQP message that is sent to the dpsim-worker, allowing more flexibility when starting simulations.

Signed-off-by: Richard Marston <rmarston@eonerc.rwth-aachen.de>